### PR TITLE
Update Settings.php

### DIFF
--- a/src/Filament/Pages/Settings.php
+++ b/src/Filament/Pages/Settings.php
@@ -87,18 +87,7 @@ class Settings extends Page
         try {
             $this->callHook('beforeValidate');
 
-            $fields = collect($this->form->getFlatFields(true));
-            $fieldsWithNestedFields = $fields->filter(fn (Field $field) => count($field->getChildComponents()) > 0);
-
-            $fieldsWithNestedFields->each(function (Field $fieldWithNestedFields, string $fieldWithNestedFieldsKey) use (&$fields) {
-                $fields = $fields->reject(function (Field $field, string $fieldKey) use ($fieldWithNestedFields, $fieldWithNestedFieldsKey) {
-                    return Str::startsWith($fieldKey, $fieldWithNestedFieldsKey . '.');
-                });
-            });
-
-            $data = $fields->mapWithKeys(function (Field $field, string $fieldKey) {
-                return [$fieldKey => data_get($this->form->getState(), $fieldKey)];
-            })->toArray();
+            $data = Arr::dot($this->form->getState());
 
             $this->callHook('afterValidate');
 


### PR DESCRIPTION
With this simple line you can save all fields in form. For example:
If you use marvinosswald/filament-input-select-affix plugin, select option will not save the value because its child component of input. If you agree this change, please merge this pull request.