### PR TITLE
Fix missing is_app_url import and add Spanish translations

### DIFF
--- a/resources/lang/es/translations.php
+++ b/resources/lang/es/translations.php
@@ -1,0 +1,16 @@
+<?php
+
+return [
+    'form' => [
+        'actions' => [
+            'save' => 'Guardar',
+        ],
+    ],
+    'page' => [
+        'title' => 'Configuraciónes',
+        'navigation_label' => 'Configuraciónes',
+    ],
+    'notifications' => [
+        'saved' => 'Guardado',
+    ],
+];

--- a/src/Filament/Pages/Settings.php
+++ b/src/Filament/Pages/Settings.php
@@ -15,6 +15,8 @@ use Filament\Support\Facades\FilamentView;
 use Illuminate\Support\Str;
 use Outerweb\Settings\Models\Setting;
 
+use function Filament\Support\is_app_url;
+
 /**
  * @property Form $form
  */


### PR DESCRIPTION
This PR includes two changes:

1. **Fix:** Adds the missing import for the is_app_url helper function in the Settings page. The error occurred when the getRedirectUrl() function was overridden, and the page tried to redirect after saving settings. The missing import for is_app_url caused an undefined function error during this redirection process, preventing the expected behavior..
2. **Feature:** Spanish translations have been added for the form and notifications on the settings page.

